### PR TITLE
Feature/webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ app:
     webhook:
         url: ${BEETLE_WEBHOOK_URL:- }
         retry: ${BEETLE_WEBHOOK_RETRY:-3}
+        token: ${BEETLE_WEBHOOK_TOKEN:- }
 
 # Log configs
 log:

--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ app:
             kubeconfig: ${BEETLE_KUBE_CLUSTER_02_CONFIG_FILE:-/app/configs/staging-cluster-kubeconfig.yaml}
             configMapName: ${BEETLE_KUBE_CLUSTER_02_CONFIG_MAP:-beetle-configs}
 
+    # HTTP Webhook
+    webhook:
+        url: ${BEETLE_WEBHOOK_URL:- }
+        retry: ${BEETLE_WEBHOOK_RETRY:-3}
+
 # Log configs
 log:
     # Log level, it can be debug, info, warn, error, panic, fatal

--- a/config.dist.yml
+++ b/config.dist.yml
@@ -61,6 +61,11 @@ app:
             kubeconfig: ${BEETLE_KUBE_CLUSTER_02_CONFIG_FILE:-/app/configs/staging-cluster-kubeconfig.yaml}
             configMapName: ${BEETLE_KUBE_CLUSTER_02_CONFIG_MAP:-beetle-configs}
 
+    # HTTP Webhook
+    webhook:
+        url: ${BEETLE_WEBHOOK_URL:- }
+        retry: ${BEETLE_WEBHOOK_RETRY:-3}
+
 # Log configs
 log:
     # Log level, it can be debug, info, warn, error, panic, fatal

--- a/config.dist.yml
+++ b/config.dist.yml
@@ -65,6 +65,7 @@ app:
     webhook:
         url: ${BEETLE_WEBHOOK_URL:- }
         retry: ${BEETLE_WEBHOOK_RETRY:-3}
+        token: ${BEETLE_WEBHOOK_TOKEN:- }
 
 # Log configs
 log:

--- a/config.testing.yml
+++ b/config.testing.yml
@@ -61,6 +61,11 @@ app:
             kubeconfig: ${BEETLE_KUBE_CLUSTER_02_CONFIG_FILE:-/app/configs/staging-cluster-kubeconfig.yaml}
             configMapName: ${BEETLE_KUBE_CLUSTER_02_CONFIG_MAP:-beetle-configs}
 
+    # HTTP Webhook
+    webhook:
+        url: ${BEETLE_WEBHOOK_URL:- }
+        retry: ${BEETLE_WEBHOOK_RETRY:-3}
+
 # Log configs
 log:
     # Log level, it can be debug, info, warn, error, panic, fatal

--- a/config.testing.yml
+++ b/config.testing.yml
@@ -65,6 +65,7 @@ app:
     webhook:
         url: ${BEETLE_WEBHOOK_URL:- }
         retry: ${BEETLE_WEBHOOK_RETRY:-3}
+        token: ${BEETLE_WEBHOOK_TOKEN:- }
 
 # Log configs
 log:

--- a/internal/app/controller/deployment.go
+++ b/internal/app/controller/deployment.go
@@ -98,6 +98,7 @@ func CreateDeployment(c *gin.Context, messages chan<- string) {
 		UUID:    uuid,
 		Payload: result,
 		Status:  model.JobPending,
+		Parent:  0,
 		Type:    model.JobDeploymentUpdate,
 	})
 

--- a/internal/app/controller/worker.go
+++ b/internal/app/controller/worker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/clivern/beetle/internal/app/util"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 // Worker controller
@@ -23,6 +24,7 @@ func Worker(workerID int, messages <-chan string) {
 	var err error
 	var job model.Job
 	var cluster *kubernetes.Cluster
+	var uuid string
 
 	messageObj := model.Message{}
 	deploymentRequest := model.DeploymentRequest{}
@@ -96,6 +98,48 @@ func Worker(workerID int, messages <-chan string) {
 			"request_version":     deploymentRequest.Version,
 			"request_strategy":    deploymentRequest.Strategy,
 		}).Info(`Worker accepted deployment request`)
+
+		// Notify if there is a webhook
+		if viper.GetString("webhook.url") != "" {
+			uuid = util.GenerateUUID4()
+
+			for db.JobExistByUUID(uuid) {
+				uuid = util.GenerateUUID4()
+			}
+
+			db.CreateJob(&model.Job{
+				UUID:    uuid,
+				Payload: job.Payload,
+				Status:  model.JobPending,
+				Parent:  messageObj.Job,
+				Type:    model.JobDeploymentNotify,
+			})
+
+			log.WithFields(log.Fields{
+				"correlation_id":      messageObj.UUID,
+				"worker_id":           workerID,
+				"job_id":              messageObj.Job,
+				"job_uuid":            job.UUID,
+				"request_cluster":     deploymentRequest.Cluster,
+				"request_namespace":   deploymentRequest.Namespace,
+				"request_application": deploymentRequest.Application,
+				"request_version":     deploymentRequest.Version,
+				"request_strategy":    deploymentRequest.Strategy,
+				"webhook_url":         viper.GetString("webhook.url"),
+			}).Info(`HTTP webhook enabled`)
+		} else {
+			log.WithFields(log.Fields{
+				"correlation_id":      messageObj.UUID,
+				"worker_id":           workerID,
+				"job_id":              messageObj.Job,
+				"job_uuid":            job.UUID,
+				"request_cluster":     deploymentRequest.Cluster,
+				"request_namespace":   deploymentRequest.Namespace,
+				"request_application": deploymentRequest.Application,
+				"request_version":     deploymentRequest.Version,
+				"request_strategy":    deploymentRequest.Strategy,
+			}).Info(`HTTP webhook disabled`)
+		}
 
 		cluster, err = kubernetes.GetCluster(deploymentRequest.Cluster)
 

--- a/internal/app/migration/schema.go
+++ b/internal/app/migration/schema.go
@@ -21,6 +21,7 @@ type Job struct {
 	Type    string    `json:"type"`
 	Result  string    `json:"result"`
 	Retry   int       `json:"retry"`
+	Parent  int       `json:"parent"`
 	RunAt   time.Time `json:"run_at"`
 }
 

--- a/internal/app/model/job.go
+++ b/internal/app/model/job.go
@@ -19,6 +19,9 @@ var (
 	// JobSuccess success job type
 	JobSuccess = "SUCCESS"
 
+	// JobOnHold on hold job type
+	JobOnHold = "ON_HOLD"
+
 	// JobDeploymentUpdate deployment update
 	JobDeploymentUpdate = "deployment.update"
 

--- a/internal/app/model/job.go
+++ b/internal/app/model/job.go
@@ -21,6 +21,9 @@ var (
 
 	// JobDeploymentUpdate deployment update
 	JobDeploymentUpdate = "deployment.update"
+
+	// JobDeploymentNotify deployment notify
+	JobDeploymentNotify = "deployment.notify"
 )
 
 // Job struct
@@ -32,6 +35,7 @@ type Job struct {
 	Type      string     `json:"type"`
 	Result    string     `json:"result"`
 	Retry     int        `json:"retry"`
+	Parent    int        `json:"parent"`
 	RunAt     *time.Time `json:"run_at"`
 	CreatedAt time.Time  `json:"created_at"`
 	UpdatedAt time.Time  `json:"updated_at"`

--- a/internal/app/model/request.go
+++ b/internal/app/model/request.go
@@ -28,6 +28,7 @@ type DeploymentRequest struct {
 	Application string `json:"application"`
 	Version     string `json:"version"`
 	Strategy    string `json:"strategy"`
+	Status      string `json:"status"`
 }
 
 // LoadFromJSON update object from json

--- a/internal/app/module/database.go
+++ b/internal/app/module/database.go
@@ -168,6 +168,15 @@ func (db *Database) GetJobByUUID(uuid string) model.Job {
 	return job
 }
 
+// GetPendingJobByType gets a job by uuid
+func (db *Database) GetPendingJobByType(jobType string) model.Job {
+	job := model.Job{}
+
+	db.Connection.Where("status = ? AND type = ?", model.JobPending, jobType).First(&job)
+
+	return job
+}
+
 // CountJobs count jobs by status
 func (db *Database) CountJobs(status string) int {
 	count := 0
@@ -195,4 +204,13 @@ func (db *Database) UpdateJobByID(job *model.Job) {
 // Close closes MySQL database connection
 func (db *Database) Close() error {
 	return db.Connection.Close()
+}
+
+// ReleaseChildJobs count jobs by status
+func (db *Database) ReleaseChildJobs(parentID int) {
+	db.Connection.Model(&model.Job{}).Where(
+		"parent = ? AND status = ?",
+		parentID,
+		model.JobOnHold,
+	).Update("status", model.JobPending)
 }

--- a/internal/app/module/database_test.go
+++ b/internal/app/module/database_test.go
@@ -90,7 +90,8 @@ func TestDatabase(t *testing.T) {
 
 		// Create the job
 		job := db.CreateJob(&model.Job{
-			UUID: "dddde755-5f99-4e51-a517-77878986a07e",
+			UUID:   "dddde755-5f99-4e51-a517-77878986a07e",
+			Parent: 0,
 		})
 
 		pkg.Expect(t, 1, job.ID)


### PR DESCRIPTION
Close #19 🎉 
 
* here is how the request will look like
```zsh
curl -X POST \
    -H "Content-Type: application/json" \
    -H "X-AUTH-TOKEN: ~webhook auth token~" \
    -H "X-NOTIFICATION-ID: ~notification job uuid~" \
    -H "X-DEPLOYMENT-ID: ~deloyment job uuid~" \
    -d '{"cluster":"production","namespace":"default","application":"toad","version":"0.2.3","strategy":"ramped","status":"success"}' \
    http://requestbin.net/r/12ev0co1f
```

* `status` could be `success`or `failed`
* you can configure the `X-AUTH-TOKEN`
* beetle will retry to deliver the notification before it marks the jobs as failed. You can configure that too